### PR TITLE
feat: make CSV URL configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# Gestión de Pedidos
+
+## Configuración de la URL del CSV
+
+La aplicación carga los pedidos desde un archivo CSV. La URL puede definirse de dos formas antes de llamar a `cargarDatos()`:
+
+1. **Variable global**
+   ```html
+   <script>
+     // Configuración para producción
+     window.URL_CSV_PEDIDOS = 'https://ejemplo.com/produccion.csv';
+   </script>
+   ```
+
+2. **Atributo HTML**
+   ```html
+   <body data-url-csv="https://ejemplo.com/pruebas.csv">
+   ```
+
+Al ejecutar `cargarDatos()` se lee primero la variable global, luego el atributo del `<body>` y por último una URL por defecto. Si ninguno de estos valores está presente, la aplicación mostrará un aviso.

--- a/index.html
+++ b/index.html
@@ -125,8 +125,12 @@
 
   <!-- Scripts de la aplicación -->
   <script>
-  // URL del CSV de Google Sheets
-  const URL_CSV_PEDIDOS = 'https://docs.google.com/spreadsheets/d/e/2PACX-1vRw3e3ilkO_gfIij6UF8qFS28GDgudfT4ikIbdH5026_GiFyk9eCVDU1hLcBg-lI7fNgHUFGXysYBbv/pub?output=csv';
+  // Configuración de la URL del CSV de Google Sheets.
+  // Puede definirse mediante:
+  // 1) Una variable global `window.URL_CSV_PEDIDOS` declarada antes de este script.
+  // 2) El atributo `data-url-csv` en el elemento `<body>`.
+  // Si no se define, se utilizará esta URL por defecto.
+  const DEFAULT_URL_CSV_PEDIDOS = 'https://docs.google.com/spreadsheets/d/e/2PACX-1vRw3e3ilkO_gfIij6UF8qFS28GDgudfT4ikIbdH5026_GiFyk9eCVDU1hLcBg-lI7fNgHUFGXysYBbv/pub?output=csv';
 
   // Datos globales
   let pedidos = [];
@@ -462,7 +466,14 @@
    * También se encarga de crear filtros y gráficos una vez cargados los datos.
    */
   function cargarDatos() {
-    Papa.parse(URL_CSV_PEDIDOS, {
+    const csvUrl = window.URL_CSV_PEDIDOS || document.body.dataset.urlCsv || DEFAULT_URL_CSV_PEDIDOS;
+    if (!csvUrl) {
+      alert('La URL del CSV de pedidos no está configurada.');
+      console.warn('URL_CSV_PEDIDOS no definida');
+      return;
+    }
+    console.log('Cargando pedidos desde:', csvUrl);
+    Papa.parse(csvUrl, {
       download: true,
       header: true,
       dynamicTyping: false,


### PR DESCRIPTION
## Summary
- allow overriding CSV URL through global `window.URL_CSV_PEDIDOS` or `<body data-url-csv>`
- log and warn when CSV URL is missing and fall back to a default value
- document environment-specific URL configuration

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68951e9aeca4832eaae8b8939f56d5ee